### PR TITLE
fixed warnings for redundant/unused imports

### DIFF
--- a/src/Benchotron/Core.purs
+++ b/src/Benchotron/Core.purs
@@ -19,28 +19,23 @@ module Benchotron.Core
 
 import Prelude
 import Data.Exists
-import Data.Identity
 import Data.Tuple
 import Data.Array (filter, (..), length, replicateM, zip)
 import Data.Array.Unsafe (head)
-import Data.String (joinWith)
 import Data.Traversable (for)
 import Data.Date (Now())
 import Data.Date.Locale (Locale())
-import Control.Apply ((<*))
 import Control.Monad.State.Trans (StateT(), evalStateT)
 import Control.Monad.State.Class (get, put)
 import Control.Monad.Trans (lift)
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Exception (EXCEPTION(), Error(), catchException,
-                                    throwException, message, error)
+import Control.Monad.Eff.Exception (EXCEPTION())
 import Control.Monad.Eff.Exception.Unsafe (unsafeThrow)
 import Node.FS (FS())
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Random  (RANDOM())
 import Test.QuickCheck.Gen (Gen(), GenState(), runGen)
 
-import Benchotron.StdIO
 import Benchotron.BenchmarkJS
 import Benchotron.Utils
 

--- a/src/Benchotron/UI/Console.purs
+++ b/src/Benchotron/UI/Console.purs
@@ -9,19 +9,19 @@ import Data.Profunctor.Strong (second, (&&&))
 import qualified Data.Array as A
 import Data.Int (fromNumber)
 import Data.String (joinWith)
-import Data.Date (now, Now())
-import Data.Date.Locale (toLocaleTimeString, Locale())
+import Data.Date (now)
+import Data.Date.Locale (toLocaleTimeString)
 import Test.QuickCheck.Gen (GenState())
 import Test.QuickCheck.LCG (runSeed, randomSeed)
 import Control.Monad.Trans (lift)
 import Control.Monad.State.Class (get)
 import Control.Monad (when)
 import Control.Monad.Eff
-import Control.Monad.Eff.Random (RANDOM(), randomInt)
+import Control.Monad.Eff.Random (RANDOM())
 import Node.FS.Sync (writeTextFile, mkdir, stat, exists)
 import Node.FS.Stats (isDirectory)
 import Node.Encoding (Encoding(..))
-import Global (readInt, isNaN)
+import Global (readInt)
 
 import Benchotron.Core
 import Benchotron.StdIO


### PR DESCRIPTION
With compiler version 0.7.6.1 there were a lot of warnings, I've fixed them all (except for the ones in dependencies).