### PR TITLE
Update project to compile on PS 0.13.0

### DIFF
--- a/src/Benchotron/UI/Console.purs
+++ b/src/Benchotron/UI/Console.purs
@@ -100,7 +100,7 @@ runBenchmarkConsole benchmark = do
   noteTime f = nowString >>= (stderrWrite <<< f)
   nowString = (JSD.toTimeString<<<JSD.fromDateTime<<<DDI.toDateTime) <$> now
   countSizes = A.length $ unpackBenchmark _.sizes benchmark
-  clearLine = "\r\ESC[K"
+  clearLine = "\r\x1b[K"
   progress idx size =
     lift $ stderrWrite $ joinWith ""
       [ clearLine


### PR DESCRIPTION
Fixes #21 

I used spago's latest package set for the bower versions.

I'm not sure which direct dependency's transitive dependency causes this, but...
```
Unable to find a suitable version for purescript-typelevel-prelude, please choose one by typing one of the numbers below:
    1) purescript-typelevel-prelude#^3.0.0 which resolved to 3.0.0 
        and is required by purescript-foreign-object#1.1.0
    2) purescript-typelevel-prelude#v5.0.0 which resolved to 5.0.0 
        and is required by purescript-benchotron
```

Selecting 2 makes it build, but I'm not sure what other downstream repercussions that would have if this library was published with that.